### PR TITLE
Removed float precision from map export code.

### DIFF
--- a/filterscripts/tstudio/tsmain.pwn
+++ b/filterscripts/tstudio/tsmain.pwn
@@ -2468,17 +2468,17 @@ MapExport(playerid, mapname[], Float:drawdist)
 				{
 					if(elistitem == 0)
 					{
-				        format(templine,sizeof(templine),"CreateObject(%i, %f, %f, %f, %f, %f, %f, %.2f);\r\n",ObjectData[i][oModel],ObjectData[i][oX],ObjectData[i][oY],ObjectData[i][oZ],ObjectData[i][oRX],ObjectData[i][oRY],ObjectData[i][oRZ],drawdist);
+				        format(templine,sizeof(templine),"tmpobjid = CreateObject(%i, %f, %f, %f, %f, %f, %f, %.2f);\r\n",ObjectData[i][oModel],ObjectData[i][oX],ObjectData[i][oY],ObjectData[i][oZ],ObjectData[i][oRX],ObjectData[i][oRY],ObjectData[i][oRZ],drawdist);
 				        fwrite(f,templine);
 					}
 					else if(elistitem == 1)
 					{
-				        format(templine,sizeof(templine),"CreateDynamicObjectEx(%i, %f, %f, %f, %f, %f, %f, %.2f, %.2f);\r\n",ObjectData[i][oModel],ObjectData[i][oX],ObjectData[i][oY],ObjectData[i][oZ],ObjectData[i][oRX],ObjectData[i][oRY],ObjectData[i][oRZ],drawdist,drawdist);
+				        format(templine,sizeof(templine),"tmpobjid = CreateDynamicObjectEx(%i, %f, %f, %f, %f, %f, %f, %.2f, %.2f);\r\n",ObjectData[i][oModel],ObjectData[i][oX],ObjectData[i][oY],ObjectData[i][oZ],ObjectData[i][oRX],ObjectData[i][oRY],ObjectData[i][oRZ],drawdist,drawdist);
 				        fwrite(f,templine);
 					}
 					else if(elistitem == 2)
 					{
-						format(templine,sizeof(templine),"CreateDynamicObject(%i, %f, %f, %f, %f, %f, %f, -1, -1, -1, %.2f, %.2f);\r\n",ObjectData[i][oModel],ObjectData[i][oX],ObjectData[i][oY],ObjectData[i][oZ],ObjectData[i][oRX],ObjectData[i][oRY],ObjectData[i][oRZ],drawdist,drawdist);
+						format(templine,sizeof(templine),"tmpobjid = CreateDynamicObject(%i, %f, %f, %f, %f, %f, %f, -1, -1, -1, %.2f, %.2f);\r\n",ObjectData[i][oModel],ObjectData[i][oX],ObjectData[i][oY],ObjectData[i][oZ],ObjectData[i][oRX],ObjectData[i][oRY],ObjectData[i][oRZ],drawdist,drawdist);
 				        fwrite(f,templine);
 					}
 				}

--- a/filterscripts/tstudio/tsmain.pwn
+++ b/filterscripts/tstudio/tsmain.pwn
@@ -2355,19 +2355,19 @@ MapExport(playerid, mapname[], Float:drawdist)
 					// Write the create object line
 					if(elistitem == 0)
 					{
-				        format(templine,sizeof(templine),"tmpobjid = CreateObject(%i,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f);\r\n",ObjectData[i][oModel],ObjectData[i][oX],ObjectData[i][oY],ObjectData[i][oZ],ObjectData[i][oRX],ObjectData[i][oRY],ObjectData[i][oRZ],drawdist);
+				        format(templine,sizeof(templine),"tmpobjid = CreateObject(%i, %f, %f, %f, %f, %f, %f, %.2f);\r\n",ObjectData[i][oModel],ObjectData[i][oX],ObjectData[i][oY],ObjectData[i][oZ],ObjectData[i][oRX],ObjectData[i][oRY],ObjectData[i][oRZ],drawdist);
 				        fwrite(f,templine);
 					}
 
 					// Write the create dynamic object line
 					else if(elistitem == 1)
 					{
-						format(templine,sizeof(templine),"tmpobjid = CreateDynamicObjectEx(%i,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f);\r\n",ObjectData[i][oModel],ObjectData[i][oX],ObjectData[i][oY],ObjectData[i][oZ],ObjectData[i][oRX],ObjectData[i][oRY],ObjectData[i][oRZ],drawdist,drawdist);
+						format(templine,sizeof(templine),"tmpobjid = CreateDynamicObjectEx(%i, %f, %f, %f, %f, %f, %f, %.2f, %.2f);\r\n",ObjectData[i][oModel],ObjectData[i][oX],ObjectData[i][oY],ObjectData[i][oZ],ObjectData[i][oRX],ObjectData[i][oRY],ObjectData[i][oRZ],drawdist,drawdist);
 				        fwrite(f,templine);
 					}
 					else if(elistitem  == 2)
 					{
-						format(templine,sizeof(templine),"tmpobjid = CreateDynamicObject(%i,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,-1,-1,-1,%.3f,%.3f);\r\n",ObjectData[i][oModel],ObjectData[i][oX],ObjectData[i][oY],ObjectData[i][oZ],ObjectData[i][oRX],ObjectData[i][oRY],ObjectData[i][oRZ],drawdist,drawdist);
+						format(templine,sizeof(templine),"tmpobjid = CreateDynamicObject(%i, %f, %f, %f, %f, %f, %f, -1, -1, -1, %.2f, %.2f);\r\n",ObjectData[i][oModel],ObjectData[i][oX],ObjectData[i][oY],ObjectData[i][oZ],ObjectData[i][oRX],ObjectData[i][oRY],ObjectData[i][oRZ],drawdist,drawdist);
 				        fwrite(f,templine);
 					}
 
@@ -2468,17 +2468,17 @@ MapExport(playerid, mapname[], Float:drawdist)
 				{
 					if(elistitem == 0)
 					{
-				        format(templine,sizeof(templine),"tmpobjid = CreateObject(%i,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f);\r\n",ObjectData[i][oModel],ObjectData[i][oX],ObjectData[i][oY],ObjectData[i][oZ],ObjectData[i][oRX],ObjectData[i][oRY],ObjectData[i][oRZ],drawdist);
+				        format(templine,sizeof(templine),"CreateObject(%i, %f, %f, %f, %f, %f, %f, %.2f);\r\n",ObjectData[i][oModel],ObjectData[i][oX],ObjectData[i][oY],ObjectData[i][oZ],ObjectData[i][oRX],ObjectData[i][oRY],ObjectData[i][oRZ],drawdist);
 				        fwrite(f,templine);
 					}
 					else if(elistitem == 1)
 					{
-				        format(templine,sizeof(templine),"tmpobjid = CreateDynamicObjectEx(%i,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f);\r\n",ObjectData[i][oModel],ObjectData[i][oX],ObjectData[i][oY],ObjectData[i][oZ],ObjectData[i][oRX],ObjectData[i][oRY],ObjectData[i][oRZ],drawdist,drawdist);
+				        format(templine,sizeof(templine),"CreateDynamicObjectEx(%i, %f, %f, %f, %f, %f, %f, %.2f, %.2f);\r\n",ObjectData[i][oModel],ObjectData[i][oX],ObjectData[i][oY],ObjectData[i][oZ],ObjectData[i][oRX],ObjectData[i][oRY],ObjectData[i][oRZ],drawdist,drawdist);
 				        fwrite(f,templine);
 					}
 					else if(elistitem == 2)
 					{
-						format(templine,sizeof(templine),"tmpobjid = CreateDynamicObject(%i,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,-1,-1,-1,%.3f,%.3f);\r\n",ObjectData[i][oModel],ObjectData[i][oX],ObjectData[i][oY],ObjectData[i][oZ],ObjectData[i][oRX],ObjectData[i][oRY],ObjectData[i][oRZ],drawdist,drawdist);
+						format(templine,sizeof(templine),"CreateDynamicObject(%i, %f, %f, %f, %f, %f, %f, -1, -1, -1, %.2f, %.2f);\r\n",ObjectData[i][oModel],ObjectData[i][oX],ObjectData[i][oY],ObjectData[i][oZ],ObjectData[i][oRX],ObjectData[i][oRY],ObjectData[i][oRZ],drawdist,drawdist);
 				        fwrite(f,templine);
 					}
 				}
@@ -2740,7 +2740,7 @@ static MapExportAll(playerid, name[], Float:drawdist)
 		{
 			mobjects++;
 
-			format(templine,sizeof(templine),"    tmpobjid = CreateDynamicObject(%i,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,-1,-1,-1,%.3f,%.3f);\r\n",ObjectData[i][oModel],ObjectData[i][oX],ObjectData[i][oY],ObjectData[i][oZ],ObjectData[i][oRX],ObjectData[i][oRY],ObjectData[i][oRZ],drawdist,drawdist);
+			format(templine,sizeof(templine),"    tmpobjid = CreateDynamicObject(%i, %f, %f, %f, %f, %f, %f, -1, -1, -1, %.2f, %.2f);\r\n",ObjectData[i][oModel],ObjectData[i][oX],ObjectData[i][oY],ObjectData[i][oZ],ObjectData[i][oRX],ObjectData[i][oRY],ObjectData[i][oRZ],drawdist,drawdist);
 	        fwrite(f,templine);
 
 			// Write all materials and colors
@@ -2799,7 +2799,7 @@ static MapExportAll(playerid, name[], Float:drawdist)
 		// Object has not been exported yet export
 		if(writeobject)
 		{
-			format(templine,sizeof(templine),"    tmpobjid = CreateDynamicObject(%i,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,-1,-1,-1,%.3f,%.3f);\r\n",ObjectData[i][oModel],ObjectData[i][oX],ObjectData[i][oY],ObjectData[i][oZ],ObjectData[i][oRX],ObjectData[i][oRY],ObjectData[i][oRZ],drawdist,drawdist);
+			format(templine,sizeof(templine),"    tmpobjid = CreateDynamicObject(%i, %f, %f, %f, %f, %f, %f, -1, -1, -1, %.2f, %.2f);\r\n",ObjectData[i][oModel],ObjectData[i][oX],ObjectData[i][oY],ObjectData[i][oZ],ObjectData[i][oRX],ObjectData[i][oRY],ObjectData[i][oRZ],drawdist,drawdist);
 	        fwrite(f,templine);
 		}
 	}


### PR DESCRIPTION
I've had a few instances where the float precision caused fine tuned objects to become misplaced slightly, creating flickering issues and etc that could only be solved by manually editing the line. I'm sure other people have had issues with this as well. I also added spacing between object coordinates to keep the lines consistent with materials and texts. Lastly, I removed unnecessary setting of the tmpobjid variable after all objects with materials and texts assigned have been printed, since I felt it only made the code look more messy than it needs to.

I figured I'd make a pull request instead of creating an issue for the sake of time. I generally dislike how messy code exported from Texture Studio looks, and if you folks feel the changes are not needed or you'd rather do it yourselves I'll understand. Even if you decide to scrap these changes, I still believe the float precision should be removed.