### PR TITLE
Crash While Mapping With Others

### DIFF
--- a/filterscripts/tstudio/cmdbuffer.pwn
+++ b/filterscripts/tstudio/cmdbuffer.pwn
@@ -11,7 +11,7 @@ new bool:HoldKeyPressed;
 OnPlayerKeyStateChangeCMD(playerid,newkeys,oldkeys)
 {
 	if(HoldKeyPressed && PRESSED(KEY_CROUCH) && !isnull(CommandBuffer[playerid][0]))
-        Command_ReProcess(playerid, CommandBuffer[playerid][0], 0); //BroadcastCommand(playerid, CommandBuffer[playerid][0]);
+        Command_ReProcess(playerid, sprintf("/%s", CommandBuffer[playerid][0]), 0); //BroadcastCommand(playerid, CommandBuffer[playerid][0]);
     
 	if(PRESSED(KEY_WALK))
         HoldKeyPressed = true;
@@ -24,7 +24,7 @@ OnPlayerKeyStateChangeCMD(playerid,newkeys,oldkeys)
 public OnPlayerCommandText(playerid, cmdtext[]) 
 {
 	//print(cmdtext);
-
+	
 	// Make every slot, start from slot 2, take the data from the slot before
 	for(new i = MAX_COMMAND_BUFFER - 1; i > 0; --i) {
 		//printf("i = %2i 1, CB[i] = %s, CB[i-1] = %s", i, CommandBuffer[playerid][i], CommandBuffer[playerid][i - 1]);
@@ -36,11 +36,12 @@ public OnPlayerCommandText(playerid, cmdtext[])
 	// Insert the command and it's parameters into the buffer
 	//CommandBuffer[playerid][0][0] = EOS;
 	format(CommandBuffer[playerid][0], 128, "%s", cmdtext);
+	strtrim(CommandBuffer[playerid][0], "/");
 
 	#if defined CB_OnPlayerCommandText
 		CB_OnPlayerCommandText(playerid, cmdtext);
 	#endif
-	return 1;
+	return 0;
 }
 #if defined _ALS_OnPlayerCommandText
 	#undef OnPlayerCommandText

--- a/filterscripts/tstudio/helpcmd.pwn
+++ b/filterscripts/tstudio/helpcmd.pwn
@@ -65,6 +65,7 @@ new Commands[][COMMAND_INFO] = {
     {1, 0, "odd"},
     
     {2, 0, "mtextures"},
+    {2, 0, "mtsearch"},
     {2, 0, "ttextures"},
     {2, 0, "stexture"},
     {2, 0, "mtset"},

--- a/filterscripts/tstudio/menugui.pwn
+++ b/filterscripts/tstudio/menugui.pwn
@@ -1619,7 +1619,7 @@ YCMD:runbind(playerid, arg[], help)
 	// Broadcast commands from command binds
 	for(new i = 0; i < MAX_BINDS_PER_BIND; i++)
 	{
-		if(!isnull(CommandBindData[bind][i])) BroadcastCommand(playerid, sprintf("%s", CommandBindData[bind][i]));
+		if(!isnull(CommandBindData[bind][i])) BroadcastCommand(playerid, CommandBindData[bind][i]);
 	}
 
 	return 1;

--- a/filterscripts/tstudio/menugui.pwn
+++ b/filterscripts/tstudio/menugui.pwn
@@ -1619,7 +1619,7 @@ YCMD:runbind(playerid, arg[], help)
 	// Broadcast commands from command binds
 	for(new i = 0; i < MAX_BINDS_PER_BIND; i++)
 	{
-		if(!isnull(CommandBindData[bind][i])) BroadcastCommand(playerid, CommandBindData[bind][i]);
+		if(!isnull(CommandBindData[bind][i])) BroadcastCommand(playerid, sprintf("%s", CommandBindData[bind][i]));
 	}
 
 	return 1;
@@ -1642,7 +1642,7 @@ YCMD:makebind(playerid, arg[], help)
 	
 	for(new x; x < range; x++) { 
 		//CommandBindData[index][x] = CommandBuffer[playerid][range - 1 - x];
-		format(CommandBindData[index][x], 128, "%s", CommandBuffer[playerid][range - 1 - x]);
+		format(CommandBindData[index][x], 128, "/%s", CommandBuffer[playerid][range - 1 - x]);
 		printf("%i: %s", x, CommandBindData[index][x]);
 	}
 	

--- a/filterscripts/tstudio/tsmain.pwn
+++ b/filterscripts/tstudio/tsmain.pwn
@@ -84,7 +84,7 @@ public OnPlayerConnect(playerid)
 			found = false;
 	}
 	if(warn)
-		printf("Warning: There's something missing or extra in /thelp for player %i.\n    (Report to Crayder on SA-MP Discord if this message ever shows)");
+		printf("Warning: There's something missing or extra in /thelp for player %i.\n    (Report to Crayder on SA-MP Discord if this message ever shows)", playerid);
 	
 	return 1;
 }
@@ -100,6 +100,8 @@ public OnPlayerDisconnect(playerid, reason)
 	ClearCopyBuffer(playerid);
 	return 1;
 }
+
+public OnPlayerClickMap(playerid, Float:fX, Float:fY, Float:fZ) return 0;
 
 SetCurrObject(playerid, index)
 {

--- a/filterscripts/tstudio/vehicles.pwn
+++ b/filterscripts/tstudio/vehicles.pwn
@@ -1,5 +1,5 @@
 
-#define         MAX_EDIT_CARS                   10
+#define         MAX_EDIT_CARS                   1000
 #define         MAX_CAR_OBJECTS         		30
 #define         MAX_CAR_COMPONENTS              14
 
@@ -190,8 +190,6 @@ YCMD:avdeletecar(playerid, arg[], help)
     MapOpenCheck();
 
 	NoEditingMode(playerid);
-
-	EditCheck(playerid);
 
 	VehicleCheck(playerid);
 	


### PR DESCRIPTION
Bug Fix: Fix Crash While Mapping With Other
Bug Fix: Remove EditCheck(playerid); From /avdeletecar
Bug Fix: Add mtsearch To /thelp
Bug Fix: Add playerid to command help missing message
Change MAX_EDIT_CARS From 10 To 1000 So You Can Create More Vehicles

EDIT: `Return 0` under `OnPlayerClickMap` so fsdebug can use this callback.